### PR TITLE
Users will now view their own posts at the top of their feed

### DIFF
--- a/src/crud/PostOperations.js
+++ b/src/crud/PostOperations.js
@@ -52,8 +52,6 @@ export async function getPostsForMutualFeed(username) {
     );
     const usersFollowedIDs = [userId];
 
-    if (usersFollowed.length === 0) return usersFollowedIDs;
-
     console.log(`Retrieved users followed for ${username}`);
 
     for (let i = 0; i < usersFollowed.length; i++) {


### PR DESCRIPTION
Their posts should not populate at the top of their feed when the posts are sorted by timestamp, which I believe Nathan is working on.