### PR TITLE
Added guard functions for following other users, also simplified the follower storage

### DIFF
--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -57,7 +57,6 @@ export default function Post(props) {
     setPicture(pic);
     try {
       const pfps3 = await Storage.get(entry.username + "/pfp.png");
-      console.log(typeof pfps3);
       setPfp(pfps3);
     } catch (error) {
       console.log("Error retrieving pfp: " + error);

--- a/src/components/modals/AddFollowerModal/AddFollowerModal.js
+++ b/src/components/modals/AddFollowerModal/AddFollowerModal.js
@@ -6,16 +6,17 @@ import { Auth } from "aws-amplify";
 
 import CustomTextInput from "../../CustomTextInput";
 import CustomButton from "../../CustomButton";
+import { getCurrentAuthenticatedUser } from "../../../library/GetAuthenticatedUser";
 
 const AddFollowerModal = ({ modalVisible, setModalVisible }) => {
   const [addFriendValue, setAddFriendValue] = useState("");
 
   async function addNewFollower() {
     try {
-      const { attributes } = await Auth.currentAuthenticatedUser();
-      let currUser = attributes.preferred_username;
+      let currUser = await getCurrentAuthenticatedUser();
       await createFollower(addFriendValue, currUser);
-      await createFollowing(currUser, addFriendValue);
+      //need to add some sort of modal for when you can't follow a user
+      //await createFollowing(currUser, addFriendValue);
     } catch (err) {
       console.error(err);
     }

--- a/src/crud/FollowersOperations.js
+++ b/src/crud/FollowersOperations.js
@@ -1,6 +1,6 @@
 import { DataStore } from "aws-amplify";
-import { User, FollowedBy } from "../models";
-import { getUserId } from "./UserOperations";
+import { User, Follows } from "../models";
+import { doesUserExist, getUserId, isCurrUser } from "./UserOperations";
 
 /**
  * This method adds an external user to the primary user's followers list
@@ -9,14 +9,13 @@ import { getUserId } from "./UserOperations";
  */
 export async function createFollower(username, followerUsername) {
   try {
+    if (await checkFollowRequirements(username, followerUsername)) {
+      return;
+    }
+
     const userId = await getUserId(username);
 
-    // if (doesFollowExist(followerUsername, userId)) {
-    //     console.log(`${followerUsername} already follows ${username}`);
-    //     return false;
-    // }
-
-    const follower = new FollowedBy({
+    const follower = new Follows({
       username: followerUsername,
       userID: userId,
     });
@@ -32,18 +31,31 @@ export async function createFollower(username, followerUsername) {
 }
 
 /**
+ * This method checks the user that the current user to trying to follow for anything that
+ * would not permit them to follow them.
+ * @param {String} username 
+ * @param {String} followerUsername 
+ * @returns Boolean
+ */
+async function checkFollowRequirements(username, followerUsername) {
+  return await isCurrUser(username) || await doesUserExist(username) || await doesFollowExist(username, followerUsername);
+}
+
+/**
  * Check to see if the following relationship exists, this is to prevent someone following the same person twice
  * @param {String} username the username of the follower
  * @param {ID} userID the ID of the user being followed
  * @returns
  */
-async function doesFollowExist(username, userID) {
+async function doesFollowExist(username, followerUsername) {
   try {
-    const followerList = await DataStore.query(FollowedBy, (f) =>
-      f.and((f) => [f.username.eq(username), f.userID.eq(userID)])
+    const userId = await getUserId(username);
+
+    const followerList = await DataStore.query(Follows, (f) =>
+      f.and((f) => [f.username.eq(followerUsername), f.userID.eq(userId)])
     );
 
-    return followerList.length >= 1 ? true : false;
+    return followerList[0] !== undefined ? true : false;
   } catch (error) {
     console.error("Error retrieving follower list");
   }
@@ -56,11 +68,9 @@ async function doesFollowExist(username, userID) {
  */
 export async function getFollowersList(username) {
   try {
-    const rootUser = await DataStore.query(User, (u) =>
-      u.username.eq(username)
-    );
-    const followersList = await DataStore.query(FollowedBy, (f) =>
-      f.userID.eq(rootUser[0].id)
+    const userId = await getUserId(username);
+    const followersList = await DataStore.query(Follows, (f) =>
+      f.userID.eq(userId)
     );
 
     console.log(`Retrieve followers of ${username} succesfully.`);
@@ -80,7 +90,7 @@ export async function deleteFollower(username, followerUsername) {
   try {
     const userId = await getUserId(username);
 
-    const followerToDelete = await DataStore.query(FollowedBy, (f) =>
+    const followerToDelete = await DataStore.query(Follows, (f) =>
       f.and((f) => [f.username.eq(followerUsername), f.userID.eq(userId)])
     );
 

--- a/src/crud/FollowingOperations.js
+++ b/src/crud/FollowingOperations.js
@@ -1,5 +1,5 @@
 import { DataStore } from "aws-amplify";
-import { User, Follows } from "../models";
+import { User, Follows, FollowedBy } from "../models";
 import { getUserId } from "./UserOperations";
 
 /**
@@ -7,14 +7,10 @@ import { getUserId } from "./UserOperations";
  * @param {String} username username of the root user i.e. the one who will be following the external user
  * @param {String} followedUsername username of the user that is to be followed
  */
+/*
 export async function createFollowing(username, followedUsername) {
   try {
     const userId = await getUserId(username);
-
-    // if (doesFollowExist(followedUsername, userId)) {
-    //   console.log(`${username} already follows ${followedUsername}`);
-    //   return false;
-    // }
 
     const follows = new Follows({
       username: followedUsername,
@@ -27,7 +23,7 @@ export async function createFollowing(username, followedUsername) {
     console.error(`There was an error trying to follow the user.}`, error);
   }
 }
-
+*/
 /**
  * Returns a list of all the people that a user follows
  * @param {String} username the user whose following list we're trying to get
@@ -35,16 +31,19 @@ export async function createFollowing(username, followedUsername) {
  */
 export async function getFollowsList(username) {
   try {
-    const rootUser = await DataStore.query(User, (u) =>
-      u.username.eq(username)
-    );
     const followsList = await DataStore.query(Follows, (f) =>
-      f.userID.eq(rootUser[0].id)
+      f.username.eq(username)
     );
 
+    const newFollowsList = [];
+
+    for (let i = 0; i < followsList.length; i++) {
+      let follow = await DataStore.query(User, followsList[i].userID);
+      newFollowsList.push(follow);
+    }
     console.log(`Successfully retrieved follows list for ${username}.`);
 
-    return followsList;
+    return newFollowsList;
   } catch (error) {
     console.error(`Error retrieving follows list for ${username}`);
   }
@@ -56,6 +55,7 @@ export async function getFollowsList(username) {
  * @param {ID} userID the ID of the user being followed
  * @returns
  */
+/*
 async function doesFollowExist(username, userID) {
   try {
     const followerList = await DataStore.query(Follows, (f) =>
@@ -66,12 +66,13 @@ async function doesFollowExist(username, userID) {
     console.error("Error retrieving follower list");
   }
 }
-
+*/
 /**
  * This method deletes the relationship between a follower and the one being followed
  * @param {String} username the username of the follower
  * @param {String} followerUsername the username of the one being followed
  */
+/*
 export async function deleteFollower(username, followerUsername) {
   try {
     const userid = await getUserId(username);
@@ -85,4 +86,6 @@ export async function deleteFollower(username, followerUsername) {
   } catch (error) {
     console.error("There was an error deleting follower.", error);
   }
+  
 }
+*/

--- a/src/crud/UserOperations.js
+++ b/src/crud/UserOperations.js
@@ -1,6 +1,7 @@
 import { DataStore } from "aws-amplify";
 import { User } from "../models";
 import { Storage } from "aws-amplify";
+import { getCurrentAuthenticatedUser } from "../library/GetAuthenticatedUser";
 
 /**
  * Creates a user and saves the new user in the backend
@@ -136,5 +137,36 @@ export async function updateBio(username, newBio) {
     console.log(`Successfully updated bio for ${username}.`);
   } catch (error) {
     console.error(`Error updating ${username} bio.`);
+  }
+}
+
+/**
+ * Checks to see if the given username is the same as the current user
+ * @param {String} username 
+ * @returns boolean
+ */
+export async function isCurrUser(username) {
+  try {
+    return username === await getCurrentAuthenticatedUser();
+  } catch (error) {
+    console.error(`Error checking is username is the current user.`, error);
+  }
+}
+
+/**
+ * Checks to see if the user with the given username exists in the database
+ * @param {String} username 
+ * @returns Boolean
+ */
+export async function doesUserExist(username) {
+  try {
+    const user = await DataStore.query(User, (u) => u.username.eq(username));
+
+    if (user[0] === undefined)
+      console.log(`This user does not exist.`);
+
+    return user[0] === undefined;
+  } catch (error) {
+    console.error(`Error checking if user exists.`, error);
   }
 }

--- a/src/screens/FollowerScreen.js
+++ b/src/screens/FollowerScreen.js
@@ -2,6 +2,7 @@ import { View, ScrollView, StyleSheet } from "react-native";
 import { useState, useEffect, useCallback } from "react";
 import { Auth } from "aws-amplify";
 
+import { DataStore } from "aws-amplify";
 import Header from "../components/Header";
 import CustomButton from "../components/CustomButton";
 import CustomTextInput from "../components/CustomTextInput";
@@ -52,11 +53,11 @@ export function FollowerScreen({ route, navigation }) {
           let currUser = attributes.preferred_username;
           if (isFollowerPage) {
             await deleteFollower(currUser, val.username);
-            await deleteFollowing(val.username, currUser);
+            //await deleteFollowing(val.username, currUser);
           } else {
             console.log(currUser);
             await deleteFollower(val.username, currUser);
-            await deleteFollowing(currUser, val.username);
+            //await deleteFollowing(currUser, val.username);
           }
           console.log("WOW done");
           setForceRefresh(!forceRefresh);


### PR DESCRIPTION
The PR addresses the 3 known bugs with our follower system. 

1) a user cannot follow themself 2) a user cannot follow a user that does not exist 3) a user cannot follow the same user twice

I also redirected all follower creation and deletion to a single followers table rather than splitting the 'follower' and 'following' data into 2 tables (it was all pretty much the same data). I commented out a lot of dead code in case we need it but if this way works better than it will be deprecated and I can delete.

Address issue #164 
