### PR TITLE
#219 fixed bug for mutual feed, now it lists all your posts and users you follow

### DIFF
--- a/src/crud/PostOperations.js
+++ b/src/crud/PostOperations.js
@@ -49,15 +49,14 @@ export async function getPostsForMutualFeed(username) {
     const userId = await getUserId(username);
 
     const usersFollowed = await DataStore.query(Follows, (uf) =>
-      uf.userID.eq(userId)
+      uf.username.eq(username)
     );
     const usersFollowedIDs = [userId];
 
     console.log(`Retrieved users followed for ${username}`);
 
     for (let i = 0; i < usersFollowed.length; i++) {
-      let usersFollowedID = await getUserId(usersFollowed[i].username);
-      usersFollowedIDs.push(usersFollowedID);
+      usersFollowedIDs.push(usersFollowed[i].userID);
     }
 
     const posts = [];


### PR DESCRIPTION
this is a small fix that addressed an issue I had where I was only seeing my own posts on my feed. Since my changes to the followers tables, the logic for the mutual feed function was backwards and needed to be corrected