### PR TITLE
#220 first commit for viewing another users profile

### DIFF
--- a/src/components/Post/Post.js
+++ b/src/components/Post/Post.js
@@ -1,10 +1,11 @@
-import { View, Image, Text, StyleSheet, Pressable } from "react-native";
+import { View, Image, Text, StyleSheet, Pressable, TouchableOpacity } from "react-native";
 import { useState, useEffect } from "react";
 import { Storage } from "@aws-amplify/storage";
 import Reactions from "../Reactions";
 import { blueThemeColor, grayThemeColor } from "../../library/constants";
 import ProfileMini from "../ProfileMini";
 import { useNavigation } from "@react-navigation/native";
+import NonCurrUserProfileModal from "../modals/NonCurrUserProfileModal.js/NonCurrUserProfileModal";
 const styles = StyleSheet.create({
   postBox: {
     height: 500,
@@ -87,6 +88,7 @@ export default function Post(props) {
   const [pfp, setPfp] = useState("");
   const [blowup,setBlowup]= useState(false);
   const navigation = useNavigation();
+  const [modalVisible, setModalVisible] = useState("");
 
   const handleBlowUp=()=>{
     setBlowup(!blowup);
@@ -107,20 +109,26 @@ export default function Post(props) {
   useEffect(() => {
     getPic();
     setBlowup(false);
-  }, [refresh]);
+  }, [refresh, modalVisible]);
 
   return (
     <View style={styles.postBox}>
+      <NonCurrUserProfileModal
+        modalVisible={modalVisible}
+        setModalVisible={setModalVisible}
+        entry={entry}>
+      </NonCurrUserProfileModal>
       <View name="Header" flexDirection="row" style={styles.postHeader}>
         <ProfileMini
           src={pfp}
           style={{ height: 42, width: 42, marginLeft: 6, marginRight: 6 }}
           imageStyle={{ height: 42, width: 42 }}
           onClick={() =>
-            navigation.navigate("Profile")
+            setModalVisible(true)
           }
-        />{/*Need to make it navigate to users specific profile*/}
-        <Text style={styles.postUsername}>{entry.username}</Text>
+        />
+        {/*Need to make it navigate to users specific profile*/}
+          <Text style={styles.postUsername}>{entry.username}</Text>
         <Text style={styles.createdAt}>{getTimeElapsed(entry.createdAt)}</Text>
       </View>
       <Pressable onPress={handleBlowUp} style={{backgroundColor:"rgba(30,144,255,0.5)", height:"78%", bottom:-20, marginTop:-20}}>

--- a/src/components/modals/ChangeBioModal/ChangeBioModal.js
+++ b/src/components/modals/ChangeBioModal/ChangeBioModal.js
@@ -10,7 +10,6 @@ const ChangeBioModal = ({modalVisible, setModalVisible}) => {
 
     async function changeBio() {
         const currUser = await getCurrentAuthenticatedUser();
-        console.log("this is happening when it shouldnt");
         await updateBio(currUser, bioValue);
         closeModal();
     };

--- a/src/components/modals/NonCurrUserProfileModal.js/NonCurrUserProfileModal.js
+++ b/src/components/modals/NonCurrUserProfileModal.js/NonCurrUserProfileModal.js
@@ -1,0 +1,75 @@
+import { Modal, Pressable, StyleSheet, View, Text, Image, TouchableOpacity } from "react-native";
+import React from "react";
+import { useEffect, useState } from "react";
+import { findUserByUsername } from "../../../crud/UserOperations";
+
+const NonCurrUserProfileModal = ({modalVisible, setModalVisible, entry}) => {
+    const [user, setUser] = useState("");
+
+    useEffect(() => {
+        getUserObject(entry);
+    })
+    
+    const closeModal = () => {
+        setModalVisible(false);
+    };
+
+    async function getUserObject(user) {
+        const userObj = await findUserByUsername(user.username);
+        setUser(userObj);
+    };
+
+    return (
+        <Modal 
+            visible={modalVisible}
+            animationType="fade"
+            transparent={true}
+            onRequestClose={closeModal}
+        >
+            <Pressable
+                onPress={closeModal}
+                style={styles.transparentView}>
+            </Pressable>
+            <View style={styles.centeredView}>
+                <View style={styles.modalView}>
+                    <Text>{user.username}</Text>
+                    <Text>{user.bio}</Text>
+                    <TouchableOpacity onPress={closeModal}>
+                    <Image source={require("../../../../assets/icons/Gymbit_Icons_Black/Back_Icon_Black.png")}></Image>
+                    </TouchableOpacity>
+                </View>
+            </View>
+        </Modal>
+    );
+
+};
+const styles = StyleSheet.create({
+    centeredView: {
+      flex: 1,
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    modalView: {
+      width: "50%",
+      backgroundColor: "white",
+      minWidth: 500,
+      minHeight: 250,
+      borderRadius: 20,
+  
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "center",
+      justifyContent: "space-around",
+    },
+    transparentView: {
+      position: "absolute",
+      left: 0,
+      top: 0,
+      width: "100%",
+      height: "100%",
+      backgroundColor: "rgba(52, 52, 52, 0.8)",
+      zIndex: -1,
+    },
+  });
+
+export default NonCurrUserProfileModal;

--- a/src/components/modals/NonCurrUserProfileModal.js/index.js
+++ b/src/components/modals/NonCurrUserProfileModal.js/index.js
@@ -1,0 +1,1 @@
+export { default } from "./NonCurrUserProfileModal";


### PR DESCRIPTION
This is the initial commit for this issue. I plan on creating a full screen modal for other users profiles rather than adding another screen. The justification is that I don't want to add another screen to the nav stack that isn't visible on the nav bar. Currently, when the user clicks on either the profile picture or username of another user on their post, a half screen modal will pop up with their username and bio. There is a back arrow as well. When completed, this will be a full screen modal and the only clickable element on another user's profile will be the back arrow to go back to the screen that the user was on before. I plan on having the username, bio, pfp, follower/following count, and maybe goals be the only visible things on another user's profile.

This same method will be applied to any area where you can click on another user's username. The follower/following page, comment sections, and like sections.